### PR TITLE
Try passing the same flag to compute the path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,12 +165,11 @@ jobs:
             # The flags passed to `stack path` need to pretty closely match
             # those passed to `stack build` or the path comes out wrong.
             # https://github.com/commercialhaskell/stack/issues/4892
-            set -x
             GETPATH="stack path \
               --haddock \
               --haddock-internal \
-              --no-haddock-deps"
-            ls -la /tmp
+              --no-haddock-deps \
+              --local-doc-root"
 
             mv $(nix-shell shell.nix --run "$GETPATH")/PaymentServer-* /tmp/PaymentServer-docs
 


### PR DESCRIPTION
From #haskell:

> that might change optimization and thereby the abi since cross-module
> inlining information will be absent with -O0 / no -O