### PR TITLE
Fix the direct Nix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,9 @@ jobs:
             # If nixpkgs changes then potentially a lot of cached packages for
             # the base system will be invalidated so we may as well drop them
             # and make a new cache with the new packages.
-            - paymentserver-nix-store-v1-{{ checksum "nixpkgs.rev" }}-{{ checksum "ristretto.nix" }}
-            - paymentserver-nix-store-v1-{{ checksum "nixpkgs.rev" }}-
-            - paymentserver-nix-store-v1-
+            - paymentserver-nix-store-v2-{{ checksum "nixpkgs.rev" }}-{{ checksum "ristretto.nix" }}
+            - paymentserver-nix-store-v2-{{ checksum "nixpkgs.rev" }}-
+            - paymentserver-nix-store-v2-
 
       - restore_cache:
           # Restore the cache of Stack's state.  This will have all of the
@@ -156,7 +156,7 @@ jobs:
 
       - save_cache:
           name: "Cache Nix Store Paths"
-          key: paymentserver-nix-store-v1-{{ checksum "nixpkgs.rev" }}-{{ checksum "ristretto.nix" }}
+          key: paymentserver-nix-store-v2-{{ checksum "nixpkgs.rev" }}-{{ checksum "ristretto.nix" }}
           paths:
             - "/nix"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,11 @@ jobs:
               --no-haddock-deps"
             nix-shell shell.nix --run "$BUILD"
 
+      - run:
+          name: "Building with Nix"
+          command: |
+            nix-build ./nix/ -A PaymentServer.components.exes."PaymentServer-exe"
+
       - save_cache:
           name: "Cache Nix Store Paths"
           key: paymentserver-nix-store-v1-{{ checksum "nixpkgs.rev" }}-{{ checksum "ristretto.nix" }}

--- a/nix/PaymentServer.nix
+++ b/nix/PaymentServer.nix
@@ -65,6 +65,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."wai-extra" or (buildDepError "wai-extra"))
           (hsPkgs."data-default" or (buildDepError "data-default"))
           (hsPkgs."warp" or (buildDepError "warp"))
+          (hsPkgs."warp-tls" or (buildDepError "warp-tls"))
           (hsPkgs."stripe-core" or (buildDepError "stripe-core"))
           (hsPkgs."text" or (buildDepError "text"))
           (hsPkgs."containers" or (buildDepError "containers"))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; } }:
 
 let
   # Pin a particular version of haskell.nix.  The particular version isn't

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,3 @@
+self: super: {
+  ristretto = super.callPackage ./ristretto.nix { };
+}

--- a/nix/privacypass-repo.nix
+++ b/nix/privacypass-repo.nix
@@ -1,0 +1,7 @@
+{ fetchFromGitHub }:
+fetchFromGitHub {
+  owner = "LeastAuthority";
+  repo = "privacypass";
+  rev = "45855401e163f8e622bd93a5c5bce13de8c8510a";
+  sha256 = "sha256:15wv8vas6x8cdicylp0m632c916p7qxq1k4lnchr8c92lldp0rv7";
+}

--- a/nix/ristretto.nix
+++ b/nix/ristretto.nix
@@ -1,0 +1,5 @@
+{ fetchFromGitHub, callPackage }:
+let
+  src = import ./privacypass-repo.nix { inherit fetchFromGitHub; };
+in
+  callPackage "${src}/ristretto.nix" { }


### PR DESCRIPTION
Previously the Nix / Stack integration allowed for builds.  However, this isn't how the real package for NixOS is actually built.  Instead, that uses the Nix "haskell.nix" library and it was untested on CI and also broken.

This adds CI and fixes the failure.
