### PR TITLE
Expose a browser facing API for charge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ jobs:
           # the cache was written (but usually it will have).
           name: "Restore Cached Dependencies"
           keys:
-            - paymentserver-v1-{{ checksum "stack.yaml" }}-{{ checksum "PaymentServer.cabal" }}
-            - paymentserver-v1-{{ checksum "stack.yaml" }}
+            - paymentserver-v2-{{ checksum "stack.yaml" }}-{{ checksum "PaymentServer.cabal" }}
+            - paymentserver-v2-{{ checksum "stack.yaml" }}
 
       - run:
           # Build just our dependencies.  It's nice to have this as a separate
@@ -124,7 +124,7 @@ jobs:
           # way we get to save the cache whether or not the test suite goes on
           # to succeed.
           name: "Cache Dependencies"
-          key: paymentserver-v1-{{ checksum "stack.yaml" }}-{{ checksum "PaymentServer.cabal" }}
+          key: paymentserver-v2-{{ checksum "stack.yaml" }}-{{ checksum "PaymentServer.cabal" }}
           paths:
             - "/root/.stack"
             - ".stack-work"

--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -25,6 +25,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , optparse-applicative
                      , aeson
+                     , bytestring
                      , servant
                      , servant-server
                      , wai
@@ -32,6 +33,7 @@ library
                      , data-default
                      , warp
                      , warp-tls
+                     , stripe-haskell
                      , stripe-core
                      , text
                      , containers

--- a/nix/PaymentServer.nix
+++ b/nix/PaymentServer.nix
@@ -57,6 +57,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
           (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."servant" or (buildDepError "servant"))
@@ -67,6 +68,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."warp" or (buildDepError "warp"))
           (hsPkgs."warp-tls" or (buildDepError "warp-tls"))
           (hsPkgs."stripe-core" or (buildDepError "stripe-core"))
+          (hsPkgs."stripe-haskell" or (buildDepError "stripe-haskell"))
           (hsPkgs."text" or (buildDepError "text"))
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."cryptonite" or (buildDepError "cryptonite"))

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -3,6 +3,8 @@
     {
       packages = ({
         "stripe-core" = (((hackage.stripe-core)."2.5.0").revisions).default;
+        "stripe-haskell" = (((hackage.stripe-haskell)."2.5.0").revisions).default;
+        "stripe-http-client" = (((hackage.stripe-http-client)."2.5.0").revisions).default;
         } // { PaymentServer = ./PaymentServer.nix; }) // {};
       };
   resolver = "lts-14.1";

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -12,9 +12,6 @@ import Text.Printf
 import Data.Maybe
   ( maybeToList
   )
-import Data.ByteString
-  ( ByteString
-  )
 import Data.Text
   ( Text
   )
@@ -49,6 +46,9 @@ import PaymentServer.Issuer
   )
 import PaymentServer.Server
   ( paymentServerApp
+  )
+import PaymentServer.Processors.Stripe
+  ( StripeSecretKey
   )
 
 import Options.Applicative
@@ -93,7 +93,7 @@ data ServerConfig = ServerConfig
   , database        :: Database
   , databasePath    :: Maybe Text
   , endpoint        :: Endpoint
-  , stripeKey       :: ByteString
+  , stripeKey       :: StripeSecretKey
   }
   deriving (Show, Eq)
 

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -11,6 +11,8 @@ import Text.Printf
   )
 import Data.Maybe
   ( maybeToList
+import Data.ByteString
+  ( ByteString
   )
 import Data.Text
   ( Text
@@ -90,6 +92,7 @@ data ServerConfig = ServerConfig
   , database        :: Database
   , databasePath    :: Maybe Text
   , endpoint        :: Endpoint
+  , stripeKey    :: ByteString
   }
   deriving (Show, Eq)
 
@@ -159,7 +162,9 @@ sample = ServerConfig
     <> help "Path to on-disk database (sqlite3 only)"
     <> showDefault ) )
   <*> (http <|> https)
-
+  <*> option str
+  ( long "stripe-key"
+    <> help "Stripe API key" )
 
 opts :: ParserInfo ServerConfig
 opts = info (sample <**> helper)
@@ -221,6 +226,8 @@ getApp config =
             exitFailure
           Right getDB -> do
             db <- getDB
-            let app = paymentServerApp issuer db
+            let port = 8081
+            let key = stripeKey config
+            let app = paymentServerApp key issuer db
             logger <- mkRequestLogger (def { outputFormat = Detailed True})
             return $ logger app

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -227,7 +227,6 @@ getApp config =
             exitFailure
           Right getDB -> do
             db <- getDB
-            let port = 8081
             let key = stripeKey config
             let app = paymentServerApp key issuer db
             logger <- mkRequestLogger (def { outputFormat = Detailed True})

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -11,6 +11,7 @@ import Text.Printf
   )
 import Data.Maybe
   ( maybeToList
+  )
 import Data.ByteString
   ( ByteString
   )

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -93,7 +93,7 @@ data ServerConfig = ServerConfig
   , database        :: Database
   , databasePath    :: Maybe Text
   , endpoint        :: Endpoint
-  , stripeKey    :: ByteString
+  , stripeKey       :: ByteString
   }
   deriving (Show, Eq)
 

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -165,7 +165,7 @@ sample = ServerConfig
   <*> (http <|> https)
   <*> option str
   ( long "stripe-key"
-    <> help "Stripe API key" )
+    <> help "Stripe Secret key" )
 
 opts :: ParserInfo ServerConfig
 opts = info (sample <**> helper)

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -131,10 +131,12 @@ webhook d _ =
 type ChargesAPI = "charge" :> ReqBody '[JSON] Charges :> Post '[JSON] Acknowledgement
 
 data Charges = Charges
-  { token :: Text
-  , voucher :: Voucher
-  , amount :: Int
-  , currency :: Text
+  { token :: Text          -- ^ The text of a Stripe tokenized payment method.
+  , voucher :: Voucher     -- ^ The voucher for which this charge will pay.
+  , amount :: Int          -- ^ The amount of the charge in the minimum
+                           -- currency unit of the target currency (eg for
+                           -- USD, cents).
+  , currency :: Text       -- ^ The currency in which the charge will be made.
   } deriving (Show, Eq)
 
 instance FromJSON Charges where

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -35,6 +35,7 @@ import Servant
   ( Server
   , Handler
   , err400
+  , ServerError(errBody)
   , throwError
   )
 import Servant.API
@@ -154,4 +155,4 @@ charge d key (Charges token voucher amount currency) = do
     Right (Charge {}) -> do
       liftIO $ payForVoucher d voucher
       return Ok
-    Left (StripeError {}) -> throwError err400
+    Left (StripeError {}) -> throwError err400 { errBody = "Stripe charge didn't succeed" }

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -22,9 +22,6 @@ import Data.Text
   ( Text
   , unpack
   )
-import Text.Printf
-  ( printf
-  )
 import Text.Read
   ( readMaybe
   )
@@ -51,7 +48,7 @@ import Servant.API
   , (:<|>)((:<|>))
   )
 import Web.Stripe.Event
-  ( Event(Event, eventId, eventCreated, eventLiveMode, eventType, eventData, eventObject, eventPendingWebHooks, eventRequest)
+  ( Event(Event, eventId, eventType, eventData)
   , EventId(EventId)
   , EventType(ChargeSucceededEvent)
   , EventData(ChargeEvent)

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -62,17 +62,16 @@ import Web.Stripe.Types
   , Currency
   )
 import Web.Stripe.Error
-  ( StripeError(..)
+  ( StripeError(StripeError)
   )
 import Web.Stripe.Charge
   ( createCharge
-  , chargeId
-  , Amount(..)
-  , TokenId(..)
+  , Amount(Amount)
+  , TokenId(TokenId)
   )
 import Web.Stripe.Client
-  ( StripeConfig(..)
-  , StripeKey(..)
+  ( StripeConfig(StripeConfig)
+  , StripeKey(StripeKey)
   )
 import Web.Stripe
   ( stripe

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -77,6 +77,8 @@ import PaymentServer.Persistence
   , VoucherDatabase(payForVoucher)
   )
 
+type StripePrivateKey = ByteString
+
 data Acknowledgement = Ok
 
 instance ToJSON Acknowledgement where
@@ -94,7 +96,7 @@ getVoucher (MetaData []) = Nothing
 getVoucher (MetaData (("Voucher", value):xs)) = Just value
 getVoucher (MetaData (x:xs)) = getVoucher (MetaData xs)
 
-stripeServer :: VoucherDatabase d => d -> ByteString -> Server StripeAPI
+stripeServer :: VoucherDatabase d => d -> StripePrivateKey -> Server StripeAPI
 stripeServer d key = webhook d
                      :<|> charge d key
 
@@ -143,7 +145,7 @@ instance FromJSON Charges where
 
 -- | call the stripe Charge API (with token, voucher in metadata, amount, currency etc
 -- and if the Charge is okay, then set the voucher as "paid" in the database.
-charge :: VoucherDatabase d => d -> ByteString -> Charges -> Handler Acknowledgement
+charge :: VoucherDatabase d => d -> StripePrivateKey -> Charges -> Handler Acknowledgement
 charge d key (Charges token voucher amount currency) = do
   let config = StripeConfig (StripeKey key) Nothing
       tokenId = TokenId token

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -101,8 +101,8 @@ getVoucher (MetaData []) = Nothing
 getVoucher (MetaData (("Voucher", value):xs)) = Just value
 getVoucher (MetaData (x:xs)) = getVoucher (MetaData xs)
 
-stripeServer :: VoucherDatabase d => d -> StripeSecretKey -> Server StripeAPI
-stripeServer d key = webhook d
+stripeServer :: VoucherDatabase d => StripeSecretKey -> d -> Server StripeAPI
+stripeServer key d = webhook d
                      :<|> charge d key
 
 -- | Process charge succeeded events

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -38,6 +38,7 @@ import Servant
   ( Server
   , Handler
   , err400
+  , err500
   , ServerError(errBody)
   , throwError
   )
@@ -169,7 +170,7 @@ charge d key (Charges token voucher amount currency) = do
               liftIO $ payForVoucher d voucher
               return Ok
             else
-            throwError err400 { errBody = "Voucher code mismatch" }
+            throwError err500 { errBody = "Voucher code mismatch" }
         _ -> throwError err400 { errBody = "Voucher code not found" }
     Left StripeError {} -> throwError err400 { errBody = "Stripe charge didn't succeed" }
     where

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -6,6 +6,7 @@ module PaymentServer.Processors.Stripe
   ( StripeAPI
   , stripeServer
   , getVoucher
+  , StripeSecretKey
   ) where
 
 import Control.Monad.IO.Class

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -81,7 +81,7 @@ import PaymentServer.Persistence
   , VoucherDatabase(payForVoucher)
   )
 
-type StripePrivateKey = ByteString
+type StripeSecretKey = ByteString
 
 data Acknowledgement = Ok
 
@@ -100,7 +100,7 @@ getVoucher (MetaData []) = Nothing
 getVoucher (MetaData (("Voucher", value):xs)) = Just value
 getVoucher (MetaData (x:xs)) = getVoucher (MetaData xs)
 
-stripeServer :: VoucherDatabase d => d -> StripePrivateKey -> Server StripeAPI
+stripeServer :: VoucherDatabase d => d -> StripeSecretKey -> Server StripeAPI
 stripeServer d key = webhook d
                      :<|> charge d key
 
@@ -149,7 +149,7 @@ instance FromJSON Charges where
 
 -- | call the stripe Charge API (with token, voucher in metadata, amount, currency etc
 -- and if the Charge is okay, then set the voucher as "paid" in the database.
-charge :: VoucherDatabase d => d -> StripePrivateKey -> Charges -> Handler Acknowledgement
+charge :: VoucherDatabase d => d -> StripeSecretKey -> Charges -> Handler Acknowledgement
 charge d key (Charges token voucher amount currency) = do
   let config = StripeConfig (StripeKey key) Nothing
       tokenId = TokenId token

--- a/src/PaymentServer/Server.hs
+++ b/src/PaymentServer/Server.hs
@@ -42,7 +42,7 @@ type PaymentServerAPI
 -- | Create a server which uses the given database.
 paymentServer :: VoucherDatabase d => ByteString -> Issuer -> d -> Server PaymentServerAPI
 paymentServer key issuer database =
-  stripeServer database key
+  stripeServer key database
   :<|> redemptionServer issuer database
 
 paymentServerAPI :: Proxy PaymentServerAPI

--- a/src/PaymentServer/Server.hs
+++ b/src/PaymentServer/Server.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | This module exposes a Servant-based Network.Wai server for payment
 -- interactions.
@@ -38,7 +39,7 @@ type PaymentServerAPI
 -- | Create a server which uses the given database.
 paymentServer :: VoucherDatabase d => Issuer -> d -> Server PaymentServerAPI
 paymentServer issuer database =
-  stripeServer database
+  stripeServer database "test"
   :<|> redemptionServer issuer database
 
 paymentServerAPI :: Proxy PaymentServerAPI

--- a/src/PaymentServer/Server.hs
+++ b/src/PaymentServer/Server.hs
@@ -8,6 +8,9 @@ module PaymentServer.Server
   ( paymentServerApp
   ) where
 
+import Data.ByteString
+  ( ByteString
+  )
 import Servant
   ( Proxy(Proxy)
   , Server
@@ -37,9 +40,9 @@ type PaymentServerAPI
   :<|> "v1" :> "redeem" :> RedemptionAPI
 
 -- | Create a server which uses the given database.
-paymentServer :: VoucherDatabase d => Issuer -> d -> Server PaymentServerAPI
-paymentServer issuer database =
-  stripeServer database "test"
+paymentServer :: VoucherDatabase d => ByteString -> Issuer -> d -> Server PaymentServerAPI
+paymentServer key issuer database =
+  stripeServer database key
   :<|> redemptionServer issuer database
 
 paymentServerAPI :: Proxy PaymentServerAPI
@@ -47,5 +50,5 @@ paymentServerAPI = Proxy
 
 -- | Create a Servant Application which serves the payment server API using
 -- the given database.
-paymentServerApp :: VoucherDatabase d => Issuer -> d -> Application
-paymentServerApp issuer = serve paymentServerAPI . paymentServer issuer
+paymentServerApp :: VoucherDatabase d => ByteString -> Issuer -> d -> Application
+paymentServerApp key issuer = serve paymentServerAPI . paymentServer key issuer

--- a/src/PaymentServer/Server.hs
+++ b/src/PaymentServer/Server.hs
@@ -8,9 +8,6 @@ module PaymentServer.Server
   ( paymentServerApp
   ) where
 
-import Data.ByteString
-  ( ByteString
-  )
 import Servant
   ( Proxy(Proxy)
   , Server
@@ -21,6 +18,7 @@ import Servant
   )
 import PaymentServer.Processors.Stripe
   ( StripeAPI
+  , StripeSecretKey
   , stripeServer
   )
 import PaymentServer.Redemption
@@ -40,7 +38,7 @@ type PaymentServerAPI
   :<|> "v1" :> "redeem" :> RedemptionAPI
 
 -- | Create a server which uses the given database.
-paymentServer :: VoucherDatabase d => ByteString -> Issuer -> d -> Server PaymentServerAPI
+paymentServer :: VoucherDatabase d => StripeSecretKey -> Issuer -> d -> Server PaymentServerAPI
 paymentServer key issuer database =
   stripeServer key database
   :<|> redemptionServer issuer database
@@ -50,5 +48,5 @@ paymentServerAPI = Proxy
 
 -- | Create a Servant Application which serves the payment server API using
 -- the given database.
-paymentServerApp :: VoucherDatabase d => ByteString -> Issuer -> d -> Application
+paymentServerApp :: VoucherDatabase d => StripeSecretKey -> Issuer -> d -> Application
 paymentServerApp key issuer = serve paymentServerAPI . paymentServer key issuer

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,6 +39,8 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - "stripe-core-2.5.0"
+  - "stripe-haskell-2.5.0"
+  - "stripe-http-client-2.5.0"
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
First cut towards #24. The `webhook` API is retained as it is. 

Tested (with emacs `restclient-mode`) with the following:
```
POST http://localhost:8081/v1/stripe/charge
Content-Type: application/json

{ "token":"tok_visa", "voucher":"abcdefg", "amount":999, "currency":"USD" }
```