### PR TITLE
Faster fingerprinting

### DIFF
--- a/misc/load-test.py
+++ b/misc/load-test.py
@@ -75,7 +75,7 @@ def mean(xs):
 
 
 def percentile(n, xs):
-    return sorted(xs)[int(len(xs) / 100 * 95)]
+    return sorted(xs)[int(len(xs) / 100 * n)]
 
 
 def median(xs):

--- a/misc/load-test.py
+++ b/misc/load-test.py
@@ -65,7 +65,7 @@ def redeem(client, index):
         duration = int((after - before) * 1000)
         print("Request complete in {}ms".format(duration))
         body = yield readBody(response)
-        assert response.code == 200, (response.code, body)
+        assert response.code == 200, (voucher, response.code, body)
         times.append(duration)
     returnValue(times)
 

--- a/src/PaymentServer/Redemption.hs
+++ b/src/PaymentServer/Redemption.hs
@@ -11,6 +11,10 @@ module PaymentServer.Redemption
   , redemptionServer
   ) where
 
+import Prelude hiding
+  ( concat
+  )
+
 import GHC.Generics
   ( Generic
   )
@@ -27,6 +31,7 @@ import Control.Monad.IO.Class
 import Data.Text
   ( Text
   , pack
+  , concat
   )
 import Data.Text.Encoding
   ( encodeUtf8
@@ -211,7 +216,4 @@ redeem issue database (Redeem voucher tokens counter) =
 -- be used as an identifier for this exact sequence of tokens.
 fingerprintFromTokens :: [BlindedToken] -> Fingerprint
 fingerprintFromTokens =
-  let
-    hash = pack . show . hashWith SHA3_512 . encodeUtf8
-  in
-    foldl (\b a -> hash $ a `mappend` b) "" . map hash
+  pack . show . hashWith SHA3_512 . encodeUtf8 . concat


### PR DESCRIPTION
Fixes #63 

Compared to 86% of time spent in this function in current master@HEAD with 30 concurrent clients and token list of length 5000, with this change only 3% of time is spent here.  This is enough so that HTTP processing overhead dominates the profile.
