### PR TITLE
Paid vouchers metrics

### DIFF
--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -20,6 +20,7 @@ library
                      , PaymentServer.Issuer
                      , PaymentServer.Persistence
                      , PaymentServer.Redemption
+                     , PaymentServer.Metrics
                      , PaymentServer.Server
                      , PaymentServer.Main
   build-depends:       base >= 4.7 && < 5
@@ -43,6 +44,7 @@ library
                      , cryptonite
                      , sqlite-simple
                      , retry
+                     , prometheus-client
   default-language:    Haskell2010
   ghc-options:       -Wmissing-import-lists -Wunused-imports
   pkgconfig-depends: libchallenge_bypass_ristretto_ffi
@@ -69,13 +71,20 @@ test-suite PaymentServer-tests
   hs-source-dirs:      test
   main-is:             Spec.hs
   other-modules:       Persistence
+                     , Metrics
   build-depends:       base
+                     , bytestring
                      , text
                      , tasty
                      , tasty-hunit
                      , directory
                      , async
                      , sqlite-simple
+                     , http-types
+                     , wai
+                     , wai-extra
+                     , servant-server
+                     , prometheus-client
                      , PaymentServer
   default-language: Haskell2010
 

--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -45,6 +45,7 @@ library
                      , sqlite-simple
                      , retry
                      , prometheus-client
+                     , servant-prometheus
   default-language:    Haskell2010
   ghc-options:       -Wmissing-import-lists -Wunused-imports
   pkgconfig-depends: libchallenge_bypass_ristretto_ffi

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -5,7 +5,10 @@
         "stripe-core" = (((hackage.stripe-core)."2.5.0").revisions).default;
         "stripe-haskell" = (((hackage.stripe-haskell)."2.5.0").revisions).default;
         "stripe-http-client" = (((hackage.stripe-http-client)."2.5.0").revisions).default;
-        } // { PaymentServer = ./PaymentServer.nix; }) // {};
+        } // {
+        PaymentServer = ./PaymentServer.nix;
+        servant-prometheus = ./servant-prometheus.nix;
+        }) // {};
       };
   resolver = "lts-14.1";
   }

--- a/nix/servant-prometheus.nix
+++ b/nix/servant-prometheus.nix
@@ -2,19 +2,19 @@ let
   buildDepError = pkg:
     builtins.throw ''
       The Haskell package set does not contain the package: ${pkg} (build dependency).
-
+      
       If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
       '';
   sysDepError = pkg:
     builtins.throw ''
       The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
-
+      
       You may need to augment the system package mapping in haskell.nix so that it can be found.
       '';
   pkgConfDepError = pkg:
     builtins.throw ''
       The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
-
+      
       You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
       '';
   exeDepError = pkg:
@@ -24,16 +24,16 @@ let
   legacyExeDepError = pkg:
     builtins.throw ''
       The Haskell package set does not contain the package: ${pkg} (executable dependency).
-
+      
       If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
       '';
   buildToolDepError = pkg:
     builtins.throw ''
       Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
-
+      
       If this is a system dependency:
       You may need to augment the system package mapping in haskell.nix so that it can be found.
-
+      
       If this is a Haskell dependency:
       If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
       '';
@@ -42,62 +42,71 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "PaymentServer"; version = "0.1.0.0"; };
-      license = "Apache-2.0";
-      copyright = "2019 Private Storage.io, LLC.";
-      maintainer = "support@privatestorage.io";
-      author = "Jean-Paul Calderone";
-      homepage = "https://github.com/privatestorageio/PaymentServer#readme";
+      identifier = { name = "servant-prometheus"; version = "0.1.0.0"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "Alex Mason <axman6@gmail.com>, Jack Kelly <jack.kelly@data61.csiro.au>";
+      author = "Alex Mason <axman6@gmail.com>, Anchor Engineering <engineering@lists.anchor.net.au>, Servant Contributors";
+      homepage = "";
       url = "";
-      synopsis = "Coordinate entities for the purchase of PrivateStorage.io vouchers.";
-      description = "";
+      synopsis = "Helpers for using prometheus with servant";
+      description = "Helpers for using prometheus with servant. Each endpoint has its own metrics allowing more detailed monitoring than wai-middleware-prometheus allows";
       buildType = "Simple";
       };
     components = {
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."utf8-string" or (buildDepError "utf8-string"))
-          (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
-          (hsPkgs."aeson" or (buildDepError "aeson"))
-          (hsPkgs."servant" or (buildDepError "servant"))
-          (hsPkgs."servant-server" or (buildDepError "servant-server"))
-          (hsPkgs."http-types" or (buildDepError "http-types"))
-          (hsPkgs."wai" or (buildDepError "wai"))
-          (hsPkgs."wai-extra" or (buildDepError "wai-extra"))
-          (hsPkgs."wai-cors" or (buildDepError "wai-cors"))
-          (hsPkgs."data-default" or (buildDepError "data-default"))
-          (hsPkgs."warp" or (buildDepError "warp"))
-          (hsPkgs."warp-tls" or (buildDepError "warp-tls"))
-          (hsPkgs."stripe-core" or (buildDepError "stripe-core"))
-          (hsPkgs."stripe-haskell" or (buildDepError "stripe-haskell"))
-          (hsPkgs."text" or (buildDepError "text"))
-          (hsPkgs."containers" or (buildDepError "containers"))
-          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
-          (hsPkgs."sqlite-simple" or (buildDepError "sqlite-simple"))
-          (hsPkgs."retry" or (buildDepError "retry"))
           (hsPkgs."prometheus-client" or (buildDepError "prometheus-client"))
-          (hsPkgs."servant-prometheus" or (buildDepError "servant-prometheus"))
-          ];
-        pkgconfig = [
-          (pkgconfPkgs."libchallenge_bypass_ristretto_ffi" or (pkgConfDepError "libchallenge_bypass_ristretto_ffi"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."wai" or (buildDepError "wai"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
           ];
         };
       exes = {
-        "PaymentServer-exe" = {
+        "bench" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."PaymentServer" or (buildDepError "PaymentServer"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."servant-prometheus" or (buildDepError "servant-prometheus"))
+            (hsPkgs."servant-server" or (buildDepError "servant-server"))
+            (hsPkgs."prometheus-client" or (buildDepError "prometheus-client"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."wai" or (buildDepError "wai"))
+            (hsPkgs."warp" or (buildDepError "warp"))
+            (hsPkgs."process" or (buildDepError "process"))
             ];
           };
-        "PaymentServer-generate-key" = {
+        };
+      tests = {
+        "spec" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."servant-prometheus" or (buildDepError "servant-prometheus"))
+            (hsPkgs."servant-server" or (buildDepError "servant-server"))
+            (hsPkgs."servant-client" or (buildDepError "servant-client"))
+            (hsPkgs."servant" or (buildDepError "servant"))
+            (hsPkgs."prometheus-client" or (buildDepError "prometheus-client"))
+            (hsPkgs."http-client" or (buildDepError "http-client"))
             (hsPkgs."text" or (buildDepError "text"))
-            (hsPkgs."PaymentServer" or (buildDepError "PaymentServer"))
+            (hsPkgs."wai" or (buildDepError "wai"))
+            (hsPkgs."warp" or (buildDepError "warp"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
             ];
           };
         };
       };
-    } // rec { src = (pkgs.lib).mkDefault ../.; }
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/PrivateStorageio/servant-prometheus.git";
+      rev = "ec21c5ed50e6f6f8e52916ce71cd68fcd0166cad";
+      sha256 = "0lswszfs52x5rpf7lj46iv77zghcbr4d05dwssi63yzjll1ixizd";
+      });
+    }

--- a/src/PaymentServer/Main.hs
+++ b/src/PaymentServer/Main.hs
@@ -72,6 +72,7 @@ import PaymentServer.Issuer
   )
 import PaymentServer.Server
   ( paymentServerApp
+  , makeMetricsMiddleware
   )
 
 import Options.Applicative
@@ -313,5 +314,6 @@ getApp config =
             let
               origins = corsOrigins config
               app = paymentServerApp origins stripeConfig' issuer db
+            metricsMiddleware <- makeMetricsMiddleware
             logger <- mkRequestLogger (def { outputFormat = Detailed True})
-            return $ logger app
+            return . logger . metricsMiddleware $ app

--- a/src/PaymentServer/Metrics.hs
+++ b/src/PaymentServer/Metrics.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module PaymentServer.Metrics
+  ( metricsAPI
+  , metricsServer
+  ) where
+
+import Data.Text.Lazy
+  ( Text
+  )
+import Data.Text.Lazy.Encoding
+  ( decodeUtf8
+  )
+
+import Prometheus
+  ( exportMetricsAsText
+  )
+
+import Servant
+  ( Proxy(Proxy)
+  , Server
+  , Handler
+  , Get
+  , PlainText
+  , (:>)
+  )
+
+type MetricsAPI = "metrics" :> Get '[PlainText] Text
+
+metricsAPI :: Proxy MetricsAPI
+metricsAPI = Proxy
+
+metricsServer :: Server MetricsAPI
+metricsServer = metrics
+
+metrics :: Handler Text
+metrics = exportMetricsAsText >>= return . decodeUtf8

--- a/src/PaymentServer/Metrics.hs
+++ b/src/PaymentServer/Metrics.hs
@@ -2,8 +2,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
+-- | A module which provides Prometheus metrics publishing.  Individual
+-- metrics are defined elsewhere in the codebase but they'll all be published
+-- by this module.
+
 module PaymentServer.Metrics
-  ( metricsAPI
+  ( MetricsAPI
+  , metricsAPI
   , metricsServer
   ) where
 

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -18,14 +18,10 @@ import Control.Exception
   ( try
   , throwIO
   )
-import Data.ByteString
-  ( ByteString
-  )
 import Data.Text
   ( Text
   , unpack
   )
-import qualified Data.Map as Map
 import Text.Read
   ( readMaybe
   )
@@ -41,8 +37,6 @@ import Data.Aeson
 import Servant
   ( Server
   , Handler
-  , err400
-  , err500
   , ServerError(ServerError, errHTTPCode, errBody, errHeaders, errReasonPhrase)
   , throwError
   )
@@ -51,21 +45,11 @@ import Servant.API
   , JSON
   , Post
   , (:>)
-  , (:<|>)((:<|>))
-  )
-import Web.Stripe.Event
-  ( Event(Event, eventId, eventType, eventData)
-  , EventId(EventId)
-  , EventType(ChargeSucceededEvent)
-  , EventData(ChargeEvent)
   )
 import Web.Stripe.Types
   ( Charge(Charge, chargeMetaData)
   , MetaData(MetaData)
   , Currency
-  )
-import Web.Stripe.Error
-  ( StripeError(StripeError)
   )
 import Web.Stripe.Charge
   ( createCharge
@@ -79,6 +63,9 @@ import Web.Stripe
   ( stripe
   , (-&-)
   )
+
+import qualified Prometheus as P
+
 import PaymentServer.Persistence
   ( Voucher
   , VoucherDatabase(payForVoucher)
@@ -126,10 +113,19 @@ instance FromJSON Charges where
                          v .: "currency"
   parseJSON _ = mzero
 
+chargeAttempts :: P.Counter
+chargeAttempts
+  = P.unsafeRegister
+  $ P.counter
+  $ P.Info "charge_attempts" "The number of attempted charge requests received."
+
 -- | call the stripe Charge API (with token, voucher in metadata, amount, currency etc
 -- and if the Charge is okay, then set the voucher as "paid" in the database.
 charge :: VoucherDatabase d => StripeConfig -> d -> Charges -> Handler Acknowledgement
 charge stripeConfig d (Charges token voucher amount currency) = do
+
+  liftIO $ P.incCounter chargeAttempts
+
   currency' <- getCurrency currency
   result <- liftIO (try (payForVoucher d voucher (completeStripeCharge currency')))
   case result of

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -89,7 +89,8 @@ getVoucher (MetaData (("Voucher", value):xs)) = Just value
 getVoucher (MetaData (x:xs)) = getVoucher (MetaData xs)
 
 stripeServer :: VoucherDatabase d => StripeConfig -> d -> Server StripeAPI
-stripeServer = charge
+stripeServer stripeConfig d =
+  withSuccessFailureMetrics chargeAttempts chargeSuccesses . charge stripeConfig d
 
 -- | Browser facing API that takes token, voucher and a few other information
 -- and calls stripe charges API. If payment succeeds, then the voucher is stored
@@ -113,19 +114,40 @@ instance FromJSON Charges where
                          v .: "currency"
   parseJSON _ = mzero
 
+
+metricName :: Text -> Text
+metricName name = mappend ("processors.stripe.charge_") name
+
 chargeAttempts :: P.Counter
 chargeAttempts
   = P.unsafeRegister
   $ P.counter
-  $ P.Info "charge_attempts" "The number of attempted charge requests received."
+  $ P.Info (metricName "attempts")
+  "The number of attempted charge requests received."
+
+
+chargeSuccesses :: P.Counter
+chargeSuccesses
+  = P.unsafeRegister
+  $ P.counter
+  $ P.Info (metricName "successes")
+  "The number of charge requests successfully processed."
+
+
+-- | run a Servant Handler, recording the attempt and whether or not it
+-- succeeds using the given counters.
+withSuccessFailureMetrics :: P.Counter -> P.Counter -> Handler a -> Handler a
+withSuccessFailureMetrics attemptCount successCount op = do
+  liftIO $ P.incCounter attemptCount
+  result <- op
+  liftIO $ P.incCounter successCount
+  return result
+
 
 -- | call the stripe Charge API (with token, voucher in metadata, amount, currency etc
 -- and if the Charge is okay, then set the voucher as "paid" in the database.
 charge :: VoucherDatabase d => StripeConfig -> d -> Charges -> Handler Acknowledgement
 charge stripeConfig d (Charges token voucher amount currency) = do
-
-  liftIO $ P.incCounter chargeAttempts
-
   currency' <- getCurrency currency
   result <- liftIO (try (payForVoucher d voucher (completeStripeCharge currency')))
   case result of

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -102,7 +102,7 @@ getVoucher (MetaData (("Voucher", value):xs)) = Just value
 getVoucher (MetaData (x:xs)) = getVoucher (MetaData xs)
 
 stripeServer :: VoucherDatabase d => StripeConfig -> d -> Server StripeAPI
-stripeServer stripeConfig d = charge d stripeConfig
+stripeServer = charge
 
 -- | Browser facing API that takes token, voucher and a few other information
 -- and calls stripe charges API. If payment succeeds, then the voucher is stored
@@ -128,8 +128,8 @@ instance FromJSON Charges where
 
 -- | call the stripe Charge API (with token, voucher in metadata, amount, currency etc
 -- and if the Charge is okay, then set the voucher as "paid" in the database.
-charge :: VoucherDatabase d => d -> StripeConfig -> Charges -> Handler Acknowledgement
-charge d stripeConfig (Charges token voucher amount currency) = do
+charge :: VoucherDatabase d => StripeConfig -> d -> Charges -> Handler Acknowledgement
+charge stripeConfig d (Charges token voucher amount currency) = do
   currency' <- getCurrency currency
   result <- liftIO (try (payForVoucher d voucher (completeStripeCharge currency')))
   case result of

--- a/src/PaymentServer/Server.hs
+++ b/src/PaymentServer/Server.hs
@@ -35,6 +35,10 @@ import PaymentServer.Redemption
   ( RedemptionAPI
   , redemptionServer
   )
+import PaymentServer.Metrics
+  ( MetricsAPI
+  , metricsServer
+  )
 import PaymentServer.Issuer
   ( Issuer
   )
@@ -46,12 +50,14 @@ import PaymentServer.Persistence
 type PaymentServerAPI
   =    "v1" :> "stripe" :> StripeAPI
   :<|> "v1" :> "redeem" :> RedemptionAPI
+  :<|> MetricsAPI
 
 -- | Create a server which uses the given database.
 paymentServer :: VoucherDatabase d => StripeConfig -> Issuer -> d -> Server PaymentServerAPI
 paymentServer stripeConfig issuer database =
   stripeServer stripeConfig database
   :<|> redemptionServer issuer database
+  :<|> metricsServer
 
 paymentServerAPI :: Proxy PaymentServerAPI
 paymentServerAPI = Proxy

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,8 @@ extra-deps:
   - "stripe-core-2.5.0"
   - "stripe-haskell-2.5.0"
   - "stripe-http-client-2.5.0"
+  - github: "PrivateStorageio/servant-prometheus"
+    commit: "ec21c5ed50e6f6f8e52916ce71cd68fcd0166cad"
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/test/Metrics.hs
+++ b/test/Metrics.hs
@@ -65,6 +65,7 @@ import PaymentServer.Persistence
 tests :: TestTree
 tests = testGroup "Metrics"
   [ metricsTests
+  , serverTests
   ]
 
 readMetrics :: Session SResponse
@@ -96,3 +97,15 @@ metricsTests =
           , "# TYPE a_counter counter"
           , "a_counter 1.0"
           ]
+
+-- | The metrics endpoint is hooked up to the overall application server.
+serverTests :: TestTree
+serverTests =
+  testCase "metrics endpoint" $
+  let
+    app :: Application
+    app = paymentServerApp mempty undefined undefined (undefined :: VoucherDatabaseState)
+  in
+    flip runSession app $ do
+      response <- readMetrics
+      assertStatus 200 response

--- a/test/Metrics.hs
+++ b/test/Metrics.hs
@@ -44,8 +44,7 @@ import Servant
   )
 
 import Prometheus
-  ( Metric
-  , Info(Info)
+  ( Info(Info)
   , unsafeRegister
   , counter
   , incCounter

--- a/test/Metrics.hs
+++ b/test/Metrics.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tests related to PaymentServer.Metrics and the metrics it exposes.
+
+module Metrics
+  ( tests
+  ) where
+
+import Data.ByteString.Lazy.Char8
+  ( pack
+  )
+
+import Test.Tasty
+  ( TestTree
+  , testGroup
+  )
+
+import Test.Tasty.HUnit
+  ( testCase
+  , assertEqual
+  )
+
+import Network.HTTP.Types
+  ( methodGet
+  )
+import Network.Wai
+  ( defaultRequest
+  , requestMethod
+  )
+import Network.Wai.Test
+  ( Session
+  , SResponse
+  , runSession
+  , setPath
+  , request
+  , assertStatus
+  , assertContentType
+  , assertBody
+  )
+
+import Servant
+  ( Application
+  , serve
+  )
+
+import Prometheus
+  ( Metric
+  , Info(Info)
+  , unsafeRegister
+  , counter
+  , incCounter
+  )
+
+import PaymentServer.Metrics
+  ( metricsAPI
+  , metricsServer
+  )
+import PaymentServer.Server
+  ( paymentServerApp
+  )
+import PaymentServer.Persistence
+  ( VoucherDatabaseState
+  )
+
+tests :: TestTree
+tests = testGroup "Metrics"
+  [ metricsTests
+  ]
+
+readMetrics :: Session SResponse
+readMetrics = request $ setPath defaultRequest { requestMethod = methodGet } "/metrics"
+
+-- Register a counter at the top-level because the registry is global and this
+-- lets us avoid thinking about collisions or unregistration.  unsafeRegister
+-- is (only) safe for defining a top-level symbol.
+aCounter = unsafeRegister $ counter (Info "a_counter" "A test counter.")
+
+metricsTests :: TestTree
+metricsTests =
+  -- | A ``GET /metrics`` request receives a text/plain OK response containing
+  -- current Prometheus-formatted metrics information.
+  testCase "plaintext metrics response" $
+  let
+    app :: Application
+    app = serve metricsAPI metricsServer
+  in
+    flip runSession app $ do
+      incCounter aCounter
+      response <- readMetrics
+      assertStatus 200 response
+      assertContentType "text/plain" response
+      assertBody expectedMetrics response
+      where
+        expectedMetrics = pack . unlines $
+          [ "# HELP a_counter A test counter."
+          , "# TYPE a_counter counter"
+          , "a_counter 1.0"
+          ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,10 +11,12 @@ import Test.Tasty
   )
 
 import qualified Persistence
+import qualified Metrics
 
 tests :: TestTree
 tests = testGroup "Tests"
   [ Persistence.tests
+  , Metrics.tests
   ]
 
 main = defaultMain tests


### PR DESCRIPTION
Fixes #56 

This adds Prometheus metrics at `/metrics` with generalized HTTP metrics as well as two specific charge counters, `processors.stripe.charge_attempts` and `processors.stripe.charge_successes`.  `charge_attempts` is incremented for every well-formed request at the charge endpoint.  `charge_successes` is incremented for every successful stripe charge with the correct metadata attached.
