### PR TITLE
Fix the charge/voucher metadata mismatch error handling case

### DIFF
--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -86,6 +86,7 @@ test-suite PaymentServer-tests
                      , wai-extra
                      , servant-server
                      , prometheus-client
+                     , stripe-core
                      , PaymentServer
   default-language: Haskell2010
 

--- a/nix/PaymentServer.nix
+++ b/nix/PaymentServer.nix
@@ -115,6 +115,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."wai-extra" or (buildDepError "wai-extra"))
             (hsPkgs."servant-server" or (buildDepError "servant-server"))
             (hsPkgs."prometheus-client" or (buildDepError "prometheus-client"))
+            (hsPkgs."stripe-core" or (buildDepError "stripe-core"))
             (hsPkgs."PaymentServer" or (buildDepError "PaymentServer"))
             ];
           };

--- a/src/PaymentServer/Persistence.hs
+++ b/src/PaymentServer/Persistence.hs
@@ -467,13 +467,16 @@ upgradeSchema targetVersion conn = do
   errOrCurrentVersion <- readVersion conn
   case errOrCurrentVersion of
     Left err -> return $ Left err
-    Right currentVersion ->
+    Right currentVersion -> perhapsUpgrade targetVersion currentVersion
+
+  where
+    perhapsUpgrade :: Int -> Int -> IO (Either UpgradeError ())
+    perhapsUpgrade targetVersion currentVersion =
       case compareVersion targetVersion currentVersion of
         Lesser -> return $ Left DatabaseSchemaTooNew
         Equal -> return $ Right ()
         Greater -> runUpgrades currentVersion targetVersion
 
-  where
     runUpgrades :: Int -> Int -> IO (Either UpgradeError ())
     runUpgrades currentVersion targetVersion =
       let

--- a/src/PaymentServer/Persistence.hs
+++ b/src/PaymentServer/Persistence.hs
@@ -452,14 +452,14 @@ upgradeSchema targetVersion conn = do
       case compareVersion targetVersion currentVersion of
         Lesser -> return $ Left DatabaseSchemaTooNew
         Equal -> return $ Right ()
-        Greater -> runUpgrades currentVersion
+        Greater -> runUpgrades currentVersion targetVersion
 
   where
-    runUpgrades :: Int -> IO (Either UpgradeError ())
-    runUpgrades currentVersion =
+    runUpgrades :: Int -> Int -> IO (Either UpgradeError ())
+    runUpgrades currentVersion targetVersion =
       let
         upgrades :: [[Sqlite.Query]]
-        upgrades = drop currentVersion updateVersions
+        upgrades = drop currentVersion $ take targetVersion updateVersions
 
         oneStep :: [Sqlite.Query] -> IO [()]
         oneStep = mapM $ Sqlite.execute_ conn

--- a/test/Persistence.hs
+++ b/test/Persistence.hs
@@ -38,13 +38,22 @@ import System.Directory
 
 import qualified Database.SQLite.Simple as Sqlite
 
+import Web.Stripe.Types
+  ( ChargeId(ChargeId)
+  )
+import Web.Stripe.Error
+  ( StripeErrorType(CardError)
+  , StripeError(StripeError)
+  )
+
 import PaymentServer.Persistence
   ( Voucher
   , Fingerprint
   , RedeemError(NotPaid, AlreadyRedeemed, DuplicateFingerprint, DatabaseUnavailable)
-  , PaymentError(AlreadyPaid)
+  , PaymentError(AlreadyPaid, PaymentFailed)
   , VoucherDatabase(payForVoucher, redeemVoucher, redeemVoucherWithCounter)
   , VoucherDatabaseState(SQLiteDB)
+  , ProcessorResult
   , memory
   , sqlite
   , upgradeSchema
@@ -70,13 +79,23 @@ anotherVoucher = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 fingerprint = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 anotherFingerprint = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 
+aChargeId :: ChargeId
+aChargeId = ChargeId "abc"
+
 -- Mock a successful payment.
-paySuccessfully :: IO ()
-paySuccessfully = return ()
+paySuccessfully :: IO ProcessorResult
+paySuccessfully = return . Right $ aChargeId
 
 -- Mock a failed payment.
-failPayment :: IO ()
+failPayment :: IO ProcessorResult
 failPayment = throwIO ArbitraryException
+
+-- Mock a payment that fails at the processor rather than with an IO
+-- exception.
+aStripeError :: StripeError
+aStripeError = StripeError CardError "Card rejected because reasons" Nothing Nothing Nothing
+failPaymentProcessing :: IO ProcessorResult
+failPaymentProcessing = return $ Left $ PaymentFailed aStripeError
 
 -- | Create a group of tests related to voucher payment and redemption.
 makeVoucherPaymentTests
@@ -96,13 +115,13 @@ makeVoucherPaymentTests label makeDatabase =
   , testCase "paid for" $ do
       connect <- makeDatabase
       conn <- connect
-      () <- payForVoucher conn voucher paySuccessfully
+      Right _ <- payForVoucher conn voucher paySuccessfully
       result <- redeemVoucher conn voucher fingerprint
       assertEqual "redeeming paid voucher" (Right True) result
   , testCase "allowed double redemption" $ do
       connect <- makeDatabase
       conn <- connect
-      () <- payForVoucher conn voucher paySuccessfully
+      Right _ <- payForVoucher conn voucher paySuccessfully
       let redeem = redeemVoucher conn voucher fingerprint
       first <- redeem
       second <- redeem
@@ -111,7 +130,7 @@ makeVoucherPaymentTests label makeDatabase =
   , testCase "disallowed double redemption" $ do
       connect <- makeDatabase
       conn <- connect
-      () <- payForVoucher conn voucher paySuccessfully
+      Right _ <- payForVoucher conn voucher paySuccessfully
       let redeem = redeemVoucher conn voucher
       first <- redeem fingerprint
       second <- redeem (Text.cons 'a' $ Text.tail fingerprint)
@@ -120,7 +139,7 @@ makeVoucherPaymentTests label makeDatabase =
   , testCase "allowed redemption varying by counter" $ do
       connect <- makeDatabase
       conn <- connect
-      () <- payForVoucher conn voucher paySuccessfully
+      Right _ <- payForVoucher conn voucher paySuccessfully
       let redeem = redeemVoucherWithCounter conn voucher
       first <- redeem fingerprint 0
       second <- redeem anotherFingerprint 1
@@ -129,12 +148,20 @@ makeVoucherPaymentTests label makeDatabase =
   , testCase "disallowed redemption varying by counter but not fingerprint" $ do
       connect <- makeDatabase
       conn <- connect
-      () <- payForVoucher conn voucher paySuccessfully
+      Right _ <- payForVoucher conn voucher paySuccessfully
       let redeem = redeemVoucherWithCounter conn voucher
       first <- redeem fingerprint 0
       second <- redeem fingerprint 1
       assertEqual "redeemed with counter 0" (Right True) first
       assertEqual "redeemed with counter 1" (Left DuplicateFingerprint) second
+  , testCase "pay with processor error" $ do
+      connect <- makeDatabase
+      conn <- connect
+      actual <- payForVoucher conn voucher failPaymentProcessing
+      let expected = Left $ PaymentFailed aStripeError
+      assertEqual "failing payment processing for a voucher" expected actual
+      result <- redeemVoucher conn voucher fingerprint
+      assertEqual "redeeming voucher with failed payment" (Left NotPaid) result
   , testCase "pay with exception" $ do
       connect <- makeDatabase
       conn <- connect
@@ -146,7 +173,7 @@ makeVoucherPaymentTests label makeDatabase =
       connect <- makeDatabase
       conn <- connect
       let pay = payForVoucher conn voucher paySuccessfully
-      () <- pay
+      Right _ <- pay
       payResult <- try pay
       assertEqual "double-paying for a voucher" (Left AlreadyPaid) payResult
       redeemResult <- redeemVoucher conn voucher fingerprint
@@ -163,15 +190,15 @@ makeVoucherPaymentTests label makeDatabase =
         withAsync anotherPayment $ \p2 -> do
           waitBoth p1 p2
 
-      assertEqual "Both payments should succeed" ((), ()) result
+      assertEqual "Both payments should succeed" (Right aChargeId, Right aChargeId) result
   , testCase "concurrent redemption" $ do
       connect <- makeDatabase
       connA <- connect
       connB <- connect
       -- It doesn't matter which connection pays for the vouchers.  They
       -- payments are concurrent and the connections are to the same database.
-      () <- payForVoucher connA voucher paySuccessfully
-      () <- payForVoucher connA anotherVoucher paySuccessfully
+      Right _ <- payForVoucher connA voucher paySuccessfully
+      Right _ <- payForVoucher connA anotherVoucher paySuccessfully
 
       -- It does matter which connection is used to redeem the voucher.  A
       -- connection can only do one thing at a time.

--- a/test/Persistence.hs
+++ b/test/Persistence.hs
@@ -247,4 +247,28 @@ sqlite3DatabaseSchemaTests =
       let expected = Right latestVersion
       actual <- readVersion conn
       assertEqual "The recorded schema version should be the latest value" expected actual
+
+  , testCase "identify version 0" $
+    -- readVersion identifies an empty database schema as version 0
+    Sqlite.withConnection ":memory:" $ \conn -> do
+      let expected = Right 0
+      actual <- readVersion conn
+      assertEqual "An empty database schema is version 0" expected actual
+
+  , testCase "identify version 1" $
+    -- readVersion identifies schema version 1
+    Sqlite.withConnection ":memory:" $ \conn -> do
+      upgradeSchema 1 conn
+      let expected = Right 1
+      actual <- readVersion conn
+      assertEqual "readVersion identifies database schema version 1" expected actual
+
+  , testCase "identify version 2" $
+    -- readVersion identifies schema version 1
+    Sqlite.withConnection ":memory:" $ \conn -> do
+      upgradeSchema 2 conn
+      let expected = Right 2
+      actual <- readVersion conn
+      assertEqual "readVersion identifies database schema version 2" expected actual
+
   ]


### PR DESCRIPTION
Remove the error case entirely and replace the metadata check with metadata storage of our own.

And ... incidentally ... fix handling of payment processor errors (as distinct from other IO exceptions).  Previously these allowed the voucher to be marked as paid even if the payment processor error indicated that no, the transaction was not completed.

Fixes #77 