### PR TITLE
Update NIXPKGS_REV to release-2105

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       # time of this comment.  We can bump it to a newer version when that
       # makes sense.  Meanwhile, the platform won't shift around beneath us
       # unexpectedly.
-      NIXPKGS_REV: "8bf142e001b6876b021c8ee90c2c7cec385fe8e9"
+      NIXPKGS_REV: "7e9b0dff974c89e070da1ad85713ff3c20b0ca97"
 
     steps:
       - run:


### PR DESCRIPTION
... so I hopefully don't have to watch CircleCI build GHC another time.

Maybe this just works and speeds up CI build times a googol.