### PR TITLE
Polish custom metric names

### DIFF
--- a/src/PaymentServer/Persistence.hs
+++ b/src/PaymentServer/Persistence.hs
@@ -304,14 +304,14 @@ redeemVoucherHelper isVoucherPaid lookupFingerprint lookupVoucherCounter markVou
 
 
 metricName :: Text -> Text
-metricName name = mappend "redemption_" name
+metricName name = mappend "payment_redemption_" name
 
 
 voucherRedeemed :: P.Counter
 voucherRedeemed
   = P.unsafeRegister
   $ P.counter
-  $ P.Info (metricName "voucher_redeemed")
+  $ P.Info (metricName "vouchers_redeemed")
   "The number of unique (voucher, counter) pairs which have been redeemed."
 
 

--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -121,7 +121,7 @@ instance FromJSON Charges where
 
 
 metricName :: Text -> Text
-metricName name = mappend ("processors_stripe_charge_") name
+metricName name = mappend ("payment_processors_stripe_charge_") name
 
 chargeAttempts :: P.Counter
 chargeAttempts

--- a/src/PaymentServer/Redemption.hs
+++ b/src/PaymentServer/Redemption.hs
@@ -227,7 +227,7 @@ redeem issue database (Redeem voucher tokens counter) =
 
 
 metricName :: Text -> Text
-metricName name = mappend "redemption_" name
+metricName name = mappend "payment_redemption_" name
 
 
 signaturesIssued :: P.Counter


### PR DESCRIPTION
Prepend `payment_` to all of our custom metric names to group metrics from PaymentServer under one name space in Prometheus.

This results in the following metrics being exported:

```
payment_processors_stripe_charge_attempts
payment_processors_stripe_charge_successes
payment_redemption_signatures_issued
payment_redemption_voucher_redeemed
```

The non-custom http endpoints continue to be available under their Prometheus style labelled names, e.g. `http_responses_total{instance="payments", path="v1/stripe/charge"}`.


### Rationale

From the [OpenMetrics spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md):

> Metric names should indicate what piece of code they come from. So a company called A Company Manufacturing Everything might prefix all metrics in their code with "acme_", and if they had a HTTP router library measuring latency it might have a metric such as "acme_http_router_request_seconds" with a Help string indicating that it is the overall latency.