### PR TITLE
Add a tool for extracting the public key from a signing key

### DIFF
--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -67,6 +67,15 @@ executable PaymentServer-generate-key
                      , PaymentServer
   default-language:    Haskell2010
 
+executable PaymentServer-get-public-key
+  hs-source-dirs:      get-public-key
+  main-is:             Main.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wmissing-import-lists -Wunused-imports
+  build-depends:       base
+                     , text
+                     , PaymentServer
+  default-language:    Haskell2010
+
 test-suite PaymentServer-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test

--- a/get-public-key/Main.hs
+++ b/get-public-key/Main.hs
@@ -1,0 +1,21 @@
+-- | Extract a public key from Ristretto-flavored PrivacyPass signing key read from stdin.
+module Main
+  ( main
+  ) where
+
+import Prelude hiding
+  ( putStrLn
+  , getLine
+  )
+
+import Data.Text.IO
+  ( putStrLn
+  , getLine
+  )
+
+import PaymentServer.Ristretto
+  ( getPublicKey
+  )
+
+main :: IO ()
+main = getLine >>= getPublicKey >>= putStrLn

--- a/nix/materialized.paymentserver/PaymentServer.nix
+++ b/nix/materialized.paymentserver/PaymentServer.nix
@@ -93,6 +93,16 @@
           hsSourceDirs = [ "generate-key" ];
           mainPath = [ "Main.hs" ];
           };
+        "PaymentServer-get-public-key" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."PaymentServer" or (errorHandler.buildDepError "PaymentServer"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "get-public-key" ];
+          mainPath = [ "Main.hs" ];
+          };
         };
       tests = {
         "PaymentServer-tests" = {

--- a/src/PaymentServer/Ristretto.hs
+++ b/src/PaymentServer/Ristretto.hs
@@ -4,6 +4,7 @@
 module PaymentServer.Ristretto
   ( Issuance(Issuance)
   , randomSigningKey
+  , getPublicKey
   , ristretto
   ) where
 
@@ -159,3 +160,14 @@ randomSigningKey = do
   result <- peekCString cString
   free cString
   return $ pack result
+
+-- | getPublicKey returns the base64 encoded public key corresponding to the
+-- base64 encoded signing key passed to it.
+getPublicKey :: Text -> IO Text
+getPublicKey enc_skey = do
+  enc_cstr_skey <- newCString . unpack $ enc_skey
+  skey <- signing_key_decode_base64 $ enc_cstr_skey
+  pkey <- signing_key_get_public_key skey
+  enc_cstr_pkey <- public_key_encode_base64 pkey
+  enc_pkey <- peekCString enc_cstr_pkey
+  return $ pack enc_pkey


### PR DESCRIPTION
If you have a Ristretto signing key then this gives you a tool for easily finding the public key.

Here's an example:

```
$ ./result/bin/PaymentServer-get-public-key <ristretto.signing-key 
ogzbCbwIl8qYQkpH1pWoAcJnSpv+UGCHveuEMr471Ew=

```