### PR TITLE
Update libchallenge bypass ristretto ffi

### DIFF
--- a/nix/challenge-bypass-ristretto-repo.nix
+++ b/nix/challenge-bypass-ristretto-repo.nix
@@ -1,9 +1,0 @@
-let
-  pkgs = import <nixpkgs> {};
-in
-  pkgs.fetchFromGitHub {
-    owner = "LeastAuthority";
-    repo = "python-challenge-bypass-ristretto";
-    rev = "v2021.07.12";
-    sha256 = "16af1qmx7srhvcc936x7hl2bz50hafm39311dbzqam9ms1i5q89j";
-  }

--- a/nix/challenge-bypass-ristretto.nix
+++ b/nix/challenge-bypass-ristretto.nix
@@ -6,4 +6,4 @@ in
 , callPackage
 , libchallenge_bypass_ristretto_ffi_repo ? sources.libchallenge_bypass_ristretto_ffi
 }:
-  import "${libchallenge_bypass_ristretto_ffi_repo}/default-challenge-bypass-ristretto-ffi.nix" { }
+  import "${libchallenge_bypass_ristretto_ffi_repo}/challenge-bypass-ristretto.nix" { }

--- a/nix/challenge-bypass-ristretto.nix
+++ b/nix/challenge-bypass-ristretto.nix
@@ -1,6 +1,9 @@
 # Provide the ffi bindings to the Rust challenge-bypass-ristretto library.
-{ fetchFromGitHub, callPackage }:
 let
-  src = import ./challenge-bypass-ristretto-repo.nix;
+  sources = import ./sources.nix;
 in
-  import "${src}/default-challenge-bypass-ristretto-ffi.nix" { }
+{ fetchFromGitHub
+, callPackage
+, libchallenge_bypass_ristretto_ffi_repo ? sources.libchallenge_bypass_ristretto_ffi
+}:
+  import "${libchallenge_bypass_ristretto_ffi_repo}/default-challenge-bypass-ristretto-ffi.nix" { }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/input-output-hk/haskell.nix/archive/f624ca56629d5be438c7d44a721b0c1d944eda23.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "libchallenge_bypass_ristretto_ffi": {
+        "branch": "master",
+        "description": "Python bindings for Brave's challenge-bypass-ristretto library",
+        "homepage": null,
+        "owner": "leastauthority",
+        "repo": "python-challenge-bypass-ristretto",
+        "rev": "v2021.07.12",
+        "sha256": "16af1qmx7srhvcc936x7hl2bz50hafm39311dbzqam9ms1i5q89j",
+        "type": "tarball",
+        "url": "https://github.com/leastauthority/python-challenge-bypass-ristretto/archive/v2021.07.12.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "libchallenge_bypass_ristretto_ffi": {
-        "branch": "master",
+        "branch": "lib-dir-is-lib-dir",
         "description": "Python bindings for Brave's challenge-bypass-ristretto library",
         "homepage": null,
         "owner": "leastauthority",
         "repo": "python-challenge-bypass-ristretto",
-        "rev": "v2021.07.12",
-        "sha256": "16af1qmx7srhvcc936x7hl2bz50hafm39311dbzqam9ms1i5q89j",
+        "rev": "7c99b67e8731486f1aa0193ac1325f77e7d6338d",
+        "sha256": "0w5vpq9kqhdbbynbbky1ibx1im5582yacqnb9y2y3h114diywdyq",
         "type": "tarball",
-        "url": "https://github.com/leastauthority/python-challenge-bypass-ristretto/archive/v2021.07.12.tar.gz",
+        "url": "https://github.com/leastauthority/python-challenge-bypass-ristretto/archive/7c99b67e8731486f1aa0193ac1325f77e7d6338d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
Fixes ever-green libchallenge_bypass_ristretto_ffi link errors.  Probably for good this time, maybe!
