### PR TITLE
Fix use of the iohk binary cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
       - run:
           name: "Building with Nix"
           command: |
+            env
             echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"
             nix-build \
               -vvvv \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       - run:
           name: "Building with Nix"
           command: |
+            echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"
             nix-build \
               -vvvv \
               --debug \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ jobs:
             nix-build \
               -vvvv \
               --debug \
-              "${EXTRA_SUBSTITUTERS}" \
-              "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
+              ${EXTRA_SUBSTITUTERS} \
+              ${EXTRA_TRUSTED_PUBLIC_KEYS} \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.exes."PaymentServer-exe"
@@ -81,8 +81,8 @@ jobs:
           name: "Building Tests"
           command: |
             nix-build \
-              "${EXTRA_SUBSTITUTERS}" \
-              "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
+              ${EXTRA_SUBSTITUTERS} \
+              ${EXTRA_TRUSTED_PUBLIC_KEYS} \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.tests."PaymentServer-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,27 @@ jobs:
     environment:
       # Add privatestorage's and haskell.nix[1] nix caches for builds.  [1]
       # https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
-      EXTRA_SUBSTITUTERS: "https://hydra.iohk.io/"
+      #
+      # - iohk gives us lots of excellent cached Haskell-related objects
+      # - saxtons gives us a lot of other nice stuff such as Rust crates and any
+      #   more Haskell libraries we might need
+      #
+      # Note the use of `>-` - YAML "folded-style chomping-strip block string"
+      # style to keep the list orderly in the source file yet represent a
+      # single line string with no trailing newline.
+      # https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines/21699210
+      # is an excellent resource on yaml strings.
+      EXTRA_SUBSTITUTERS: >-
+        https://hydra.iohk.io/
+        http://saxtons.private.storage/
 
       # We needed to explictly specify the key for cache.nixos.org until we
       # are using a version of nix that has
       # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
-      TRUSTED_PUBLIC_KEYS: "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      TRUSTED_PUBLIC_KEYS: >-
+        cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+        hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+        saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY=
 
     steps:
       # Get *our* source code.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       # Run in a highly Nix-capable environment.  This lets us use Stack's nix
       # integration and other useful Nix features to specify and run the
       # build.
-      - image: "nixorg/nix:circleci"
+      - image: "nixos/nix:2.3.16"
 
     resource_class: "xlarge"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           command: |
             # Set XDG_CONFIG_DIRS to point at the source directory, so that nix
             # will pickup nix/nix.conf as a configuration file from there.
+            set -x
             echo "export XDG_CONFIG_DIRS=$CIRCLE_WORKING_DIRECTORY" >> $BASH_ENV
 
       # Get *our* source code.
@@ -63,6 +64,9 @@ jobs:
       - run:
           name: "Building with Nix"
           command: |
+            echo "BASH_ENV: $BASH_ENV"
+            cat $BASH_ENV
+            echo
             echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"
             nix-build \
               -vvvv \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             # Set XDG_CONFIG_DIRS to point at the source directory, so that nix
             # will pickup nix/nix.conf as a configuration file from there.
-            set -x
+            echo "Shell: $0"
             echo "export XDG_CONFIG_DIRS=$CIRCLE_WORKING_DIRECTORY" >> $BASH_ENV
 
       # Get *our* source code.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,6 @@ jobs:
             env
             echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"
             nix-build \
-              -vvvv \
-              --debug \
               --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
               --option trusted-public-keys "${TRUSTED_PUBLIC_KEYS}" \
               -j 4 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
             # If nixpkgs changes then potentially a lot of cached packages for
             # the base system will be invalidated so we may as well drop them
             # and make a new cache with the new packages.
-            - paymentserver-nix-store-v6-{{ checksum "nix/sources.json" }}
-            - paymentserver-nix-store-v6-
+            - paymentserver-nix-store-v7-{{ checksum "nix/sources.json" }}
+            - paymentserver-nix-store-v7-
 
       - run:
           name: "Building with Nix"
@@ -104,7 +104,7 @@ jobs:
 
       - save_cache:
           name: "Cache Nix Store Paths"
-          key: paymentserver-nix-store-v6-{{ checksum "nix/sources.json" }}
+          key: paymentserver-nix-store-v7-{{ checksum "nix/sources.json" }}
           paths:
             - "/nix"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,8 @@ version: 2.1
 jobs:
   build:
     docker:
-      # Run in a highly Nix-capable environment.  This lets us use Stack's nix
-      # integration and other useful Nix features to specify and run the
-      # build.
+      # Run in a highly Nix-capable environment.  This lets build with Nix
+      # directly.
       - image: "nixos/nix:2.3.16"
 
     resource_class: "xlarge"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,10 @@ jobs:
 
     resource_class: "xlarge"
 
-    steps:
-      - run:
-          name: "Setup Environment Variables"
-          command: |
-            # Set XDG_CONFIG_DIRS to point at the source directory, so that nix
-            # will pickup nix/nix.conf as a configuration file from there.
-            echo "Shell: $0"
-            echo "export XDG_CONFIG_DIRS=$CIRCLE_WORKING_DIRECTORY" >> $BASH_ENV
+    environment:
+      XDG_CONFIG_DIRS: "/root/project"
 
+    steps:
       # Get *our* source code.
       - "checkout"
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,6 @@ jobs:
       - run:
           name: "Building with Nix"
           command: |
-            env
-            echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"
             nix-build \
               --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
               --option trusted-public-keys "${TRUSTED_PUBLIC_KEYS}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,12 @@ jobs:
     environment:
       # Add privatestorage's and haskell.nix[1] nix caches for builds.  [1]
       # https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
-      EXTRA_SUBSTITUTERS: "http://saxtons.private.storage/ https://hydra.iohk.io/"
+      EXTRA_SUBSTITUTERS: "https://hydra.iohk.io/"
 
       # We needed to explictly specify the key for cache.nixos.org until we
       # are using a version of nix that has
       # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
-      TRUSTED_PUBLIC_KEYS: "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      TRUSTED_PUBLIC_KEYS: "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
 
     steps:
       # Get *our* source code.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       # We needed to explictly specify the key for cache.nixos.org until we
       # are using a version of nix that has
       # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
-      EXTRA_TRUSTED_PUBLIC_KEYS: "saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      TRUSTED_PUBLIC_KEYS: "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
 
     steps:
       # Get *our* source code.
@@ -72,7 +72,7 @@ jobs:
               -vvvv \
               --debug \
               --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
-              --option extra-trusted-public-keys "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
+              --option trusted-public-keys "${TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.exes."PaymentServer-exe"
@@ -82,7 +82,7 @@ jobs:
           command: |
             nix-build \
               --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
-              --option extra-trusted-public-keys "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
+              --option trusted-public-keys "${TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.tests."PaymentServer-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,14 @@ jobs:
     resource_class: "xlarge"
 
     environment:
-      XDG_CONFIG_DIRS: "/root/project"
+      NIX_CONFIG: |
+        # Add privatestorage's and haskell.nix[1] nix caches for builds.  [1]
+        # https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
+        extra-substituters = http://saxtons.private.storage/ https://hydra.iohk.io/
+        # We needed to explictly specify the key for cache.nixos.org until we
+        # are using a version of nix that has
+        # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
+        extra-trusted-public-keys = saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
     steps:
       # Get *our* source code.
@@ -59,9 +66,6 @@ jobs:
       - run:
           name: "Building with Nix"
           command: |
-            echo "BASH_ENV: $BASH_ENV"
-            cat $BASH_ENV
-            echo
             echo "XDG_CONFIG_DIRS: $XDG_CONFIG_DIRS"
             nix-build \
               -vvvv \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ jobs:
             nix-build \
               -vvvv \
               --debug \
-              --extra-substituters="${EXTRA_SUBSTITUTERS}" \
-              --extra-trusted-public-keys"${EXTRA_TRUSTED_PUBLIC_KEYS}" \
+              --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
+              --option extra-trusted-public-keys "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.exes."PaymentServer-exe"
@@ -81,8 +81,8 @@ jobs:
           name: "Building Tests"
           command: |
             nix-build \
-              --extra-substituters="${EXTRA_SUBSTITUTERS}" \
-              --extra-trusted-public-keys"${EXTRA_TRUSTED_PUBLIC_KEYS}" \
+              --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
+              --option extra-trusted-public-keys "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.tests."PaymentServer-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,12 @@ jobs:
     environment:
       # Add privatestorage's and haskell.nix[1] nix caches for builds.  [1]
       # https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
-      EXTRA_SUBSTITUTERS: "--extra-substituters='http://saxtons.private.storage/ https://hydra.iohk.io/'"
+      EXTRA_SUBSTITUTERS: "http://saxtons.private.storage/ https://hydra.iohk.io/"
 
       # We needed to explictly specify the key for cache.nixos.org until we
       # are using a version of nix that has
       # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
-      EXTRA_TRUSTED_PUBLIC_KEYS: "--extra-trusted-public-keys='saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ='"
+      EXTRA_TRUSTED_PUBLIC_KEYS: "saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
 
     steps:
       # Get *our* source code.
@@ -71,8 +71,8 @@ jobs:
             nix-build \
               -vvvv \
               --debug \
-              ${EXTRA_SUBSTITUTERS} \
-              ${EXTRA_TRUSTED_PUBLIC_KEYS} \
+              --extra-substituters="${EXTRA_SUBSTITUTERS}" \
+              --extra-trusted-public-keys"${EXTRA_TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.exes."PaymentServer-exe"
@@ -81,8 +81,8 @@ jobs:
           name: "Building Tests"
           command: |
             nix-build \
-              ${EXTRA_SUBSTITUTERS} \
-              ${EXTRA_TRUSTED_PUBLIC_KEYS} \
+              --extra-substituters="${EXTRA_SUBSTITUTERS}" \
+              --extra-trusted-public-keys"${EXTRA_TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.tests."PaymentServer-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,8 @@ jobs:
           name: "Building with Nix"
           command: |
             nix-build \
+              -vvvv \
+              --debug \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.exes."PaymentServer-exe"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,14 +25,14 @@ jobs:
     resource_class: "xlarge"
 
     environment:
-      NIX_CONFIG: |
-        # Add privatestorage's and haskell.nix[1] nix caches for builds.  [1]
-        # https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
-        extra-substituters = http://saxtons.private.storage/ https://hydra.iohk.io/
-        # We needed to explictly specify the key for cache.nixos.org until we
-        # are using a version of nix that has
-        # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
-        extra-trusted-public-keys = saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+      # Add privatestorage's and haskell.nix[1] nix caches for builds.  [1]
+      # https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
+      EXTRA_SUBSTITUTERS: "--extra-substituters='http://saxtons.private.storage/ https://hydra.iohk.io/'"
+
+      # We needed to explictly specify the key for cache.nixos.org until we
+      # are using a version of nix that has
+      # https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
+      EXTRA_TRUSTED_PUBLIC_KEYS: "--extra-trusted-public-keys='saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ='"
 
     steps:
       # Get *our* source code.
@@ -71,6 +71,8 @@ jobs:
             nix-build \
               -vvvv \
               --debug \
+              "${EXTRA_SUBSTITUTERS}" \
+              "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.exes."PaymentServer-exe"
@@ -79,6 +81,8 @@ jobs:
           name: "Building Tests"
           command: |
             nix-build \
+              "${EXTRA_SUBSTITUTERS}" \
+              "${EXTRA_TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
               ./nix/ \
               -A PaymentServer.components.tests."PaymentServer-tests"

--- a/nix/nix.conf
+++ b/nix/nix.conf
@@ -1,8 +1,0 @@
-# nix.conf for usage in CI.
-
-# Add privatestorage's and haskell.nix[1] nix caches for builds.
-# [1] https://input-output-hk.github.io/haskell.nix/tutorials/getting-started/#setting-up-the-binary-cache
-extra-substituters = http://saxtons.private.storage/ https://hydra.iohk.io/
-# We needed to explictly specify the key for cache.nixos.org until we are using a version of nix
-# that has https://github.com/NixOS/nix/commit/ff4dea63c9403880500f82ce273713ecf793d2d9
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= saxtons.private.storage:MplOcEH8G/6mRlhlKkbA8GdeFR3dhCFsSszrspE/ZwY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=


### PR DESCRIPTION
Jobs stopped using the iohk cache, probably in October, with this error:

```
warning: unable to download 'https://hydra.iohk.io/nix-cache-info': SSL peer certificate or SSH remote key was not OK (60); retrying in ...
```

hydra.iohk.io uses a Let's Encrypt certificate so this error is probably caused by the ~3 year old image we were using lacking the "ISRG Root X1" in its trust roots.  The older CA certificate "DST Root CA X3" expired in October 2021.
    
The nixos image previous used is marked as deprecated on Docker Hub and hasn't been updated in some time.

The nixos image used elsewhere (eg in ZKAPAuthorizer) doesn't use bash so switching to it breaks the way we supply configuration to nix.  This is enough to prevent it from using the iohk cache, too, so this PR also changes the way we supply that configuration.

I tested several intermediate revisions of this branch to make sure they would actually fetch objects from the iohk cache when needed for the build and available from that cache.  "Warm" build time (no CircleCI cache but good objects in iohk and saxtons) is around 10m20s, much of which is spent downloading objects from caches.  I left the CircleCI cache configured because downloading from it is much, much faster.  "Hot" build time (with a populated CircleCI cache) is around 2m.

I'm still mystified by the whole CircleCI cache key system.  Their docs on "partial cache restore" read like word salad to me.  So I've left the very simple sources.json checksum-based key rather than trying to add more layers.
