### PR TITLE
Expose details about Stripe failures

### DIFF
--- a/test/FakeStripe.hs
+++ b/test/FakeStripe.hs
@@ -6,6 +6,8 @@ module FakeStripe
   , withFakeStripe
   , chargeOkay
   , chargeFailed
+  , cardError
+  , apiError
   ) where
 
 import Text.RawString.QQ
@@ -48,13 +50,24 @@ import Web.Stripe.Types
   ( ChargeId(ChargeId)
   )
 
-anError :: ByteString
-anError = [r|
+cardError :: ByteString
+cardError = [r|
 {
   "error": {
     "type": "card_error",
     "code": "expired_card",
     "message": "Your card is expired."
+  }
+}
+|]
+
+apiError :: ByteString
+apiError = [r|
+{
+  "error": {
+    "type": "api_error",
+    "code": "api_key_expired",
+    "message": "The API key provided has expired."
   }
 }
 |]
@@ -163,9 +176,9 @@ chargeOkay :: Application
 chargeOkay req respond =
   respond . responseLBS status200 [] $ aCharge
 
-chargeFailed :: Application
-chargeFailed req respond =
-  respond . responseLBS status400 [] $ anError
+chargeFailed :: ByteString -> Application
+chargeFailed stripeResponse req respond =
+  respond . responseLBS status400 [] $ stripeResponse
 
 -- Pass a Stripe-flavored configuration for a running Wai application to a
 -- function and evaluate the resulting IO action.

--- a/test/Stripe.hs
+++ b/test/Stripe.hs
@@ -94,6 +94,8 @@ import FakeStripe
   ( withFakeStripe
   , chargeOkay
   , chargeFailed
+  , cardError
+  , apiError
   )
 
 tests :: TestTree
@@ -115,7 +117,7 @@ corsTests =
     assertCORSHeader chargeOkay "GET" applicationJSON validChargeBytes
 
   , testCase "a request associated with an error from Stripe receives a CORS-enabled response" $
-    assertCORSHeader chargeFailed "POST" applicationJSON validChargeBytes
+    assertCORSHeader (chargeFailed cardError) "POST" applicationJSON validChargeBytes
 
   , testCase "a request with a valid charge in the body receives a CORS-enabled response" $
     assertCORSHeader chargeOkay "POST" applicationJSON validChargeBytes
@@ -168,27 +170,43 @@ chargeTests =
       let amount = 650
       let currency = AED
       db <- memory
-      (Left (ServerError code _ body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
+      (Left (ServerError code phrase body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
       assertEqual "The result is an error" 400 code
+      assertEqual "The HTTP phrase matches the code" "Bad Request" phrase
       assertEqual "The JSON body includes the reason" (Just $ Failure "Unsupported currency") (decode body)
+
   , testCase "incorrect USD amount is rejected" $
     withFakeStripe (return chargeOkay) $ \stripeConfig -> do
       let amount = 649
       let currency = USD
       db <- memory
-      (Left (ServerError code _ body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
+      (Left (ServerError code phrase body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
       assertEqual "The result is an error" 400 code
+      assertEqual "The HTTP phrase matches the code" "Bad Request" phrase
       assertEqual "The JSON body includes the reason" (Just $ Failure "Incorrect charge amount") (decode body)
+
   , testCase "a Stripe charge failure is propagated" $
-    withFakeStripe (return chargeFailed) $ \stripeConfig -> do
+    withFakeStripe (return (chargeFailed cardError)) $ \stripeConfig -> do
       let amount = 650
       let currency = USD
       db <- memory
-      (Left (ServerError code _ body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
+      (Left (ServerError code phrase body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
       assertEqual "The result is an error" 400 code
-      -- The chargeFailed fixture is hard-coded for a card expired error.
+      assertEqual "The HTTP phrase matches the code" "Bad Request" phrase
+      -- The `cardError` is for a card expired error.
       assertEqual "The JSON body includes the reason"
         (Just $ Failure "Stripe charge didn't succeed: Your card is expired.") (decode body)
+
+  , testCase "the HTTP error code is derived from the specific failure" $
+    withFakeStripe (return (chargeFailed apiError)) $ \stripeConfig -> do
+      let amount = 650
+      let currency = USD
+      db <- memory
+      (Left (ServerError code phrase body _)) <- runExceptT . runHandler' $ charge stripeConfig db (Charges token voucher amount currency)
+      -- The `apiError` is for a Stripe API error.
+      assertEqual "The result is an error" 503 code
+      assertEqual "The HTTP phrase matches the code" "Service Unavailable" phrase
+
   , testCase "currect USD amount is accepted" $
     withFakeStripe (return chargeOkay) $ \stripeConfig -> do
       let amount = 650


### PR DESCRIPTION
Fixes #112 

This puts the Stripe details into the JSON body and makes sure the standard error phrase is always present.
