### PR TITLE
Remove the "stair-step" pattern from Ristretto.hs

### DIFF
--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -46,6 +46,7 @@ library
                      , retry
                      , prometheus-client
                      , servant-prometheus
+                     , mtl
   default-language:    Haskell2010
   ghc-options:       -Wmissing-import-lists -Wunused-imports
   pkgconfig-depends: libchallenge_bypass_ristretto_ffi

--- a/shell.nix
+++ b/shell.nix
@@ -8,9 +8,10 @@ in
     # *all* dependencies are provided by Nix.
     exactDeps = true;
 
-    withHoogle = false;
+    withHoogle = true;
 
     buildInputs = [
       pkgs.stack
+      pkgs.ormolu
     ];
   }

--- a/shell.nix
+++ b/shell.nix
@@ -8,10 +8,9 @@ in
     # *all* dependencies are provided by Nix.
     exactDeps = true;
 
-    withHoogle = true;
+    withHoogle = false;
 
     buildInputs = [
       pkgs.stack
-      pkgs.ormolu
     ];
   }

--- a/src/PaymentServer/Ristretto.hs
+++ b/src/PaymentServer/Ristretto.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE RankNTypes #-}
 
 module PaymentServer.Ristretto
   ( Issuance(Issuance)
@@ -9,9 +8,6 @@ module PaymentServer.Ristretto
   , ristretto
   ) where
 
-import Control.Monad
-  ( liftM
-  )
 import Control.Exception
   ( bracket
   )


### PR DESCRIPTION
This is a minor code cleanup.  It replaces carefully crafted and repetitive error handling in `ristretto` with `ExceptT` and a couple reusable helpers.
