### PR TITLE
Update Haskell.nix and the stack resolver

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,7 +21,7 @@ let
     # haskell.nix provides access to the nixpkgs pins which are used by our CI,
     # hence you will be more likely to get cache hits when using these.
     # But you can also just use your own, e.g. '<nixpkgs>'.
-    haskellNix.sources.nixpkgs-2111
+    haskellNix.sources.nixpkgs-2205
     # These arguments passed to nixpkgs, include some patches and also
     # the haskell.nix functionality itself as an overlay.
     (haskellNix.nixpkgsArgs // { overlays = allOverlays; });

--- a/nix/materialized.paymentserver/PaymentServer.nix
+++ b/nix/materialized.paymentserver/PaymentServer.nix
@@ -142,6 +142,4 @@
           };
         };
       };
-    } // rec {
-    src = (pkgs.lib).mkDefault ./.;
-    }
+    } // rec { src = (pkgs.lib).mkDefault ./.; }

--- a/nix/materialized.paymentserver/default.nix
+++ b/nix/materialized.paymentserver/default.nix
@@ -2,14 +2,11 @@
   extras = hackage:
     {
       packages = {
-        "stripe-core" = (((hackage.stripe-core)."2.5.0").revisions).default;
-        "stripe-haskell" = (((hackage.stripe-haskell)."2.5.0").revisions).default;
-        "stripe-http-client" = (((hackage.stripe-http-client)."2.5.0").revisions).default;
         PaymentServer = ./PaymentServer.nix;
         servant-prometheus = ./.stack-to-nix.cache.0;
         };
       };
-  resolver = "lts-14.2";
+  resolver = "lts-18.28";
   modules = [
     ({ lib, ... }:
       { packages = {}; })

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e95a1f0dacbc64603c31d11e36e4ba1af8f0eb43",
-        "sha256": "160cf7ha2c5wkbymy3h4skzw1l3x4i8dhj2arvq3bdz92gg1d6cb",
+        "rev": "4e01f345439c89bc2a5616ceda08a979a01bc15e",
+        "sha256": "02n3ag3zcig60x93hh9v2vnhyw6qmzr9qg8dpnr4ac4ym8cyifc9",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/e95a1f0dacbc64603c31d11e36e4ba1af8f0eb43.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/4e01f345439c89bc2a5616ceda08a979a01bc15e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "libchallenge_bypass_ristretto_ffi": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-14.2
+resolver: lts-18.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -38,9 +38,6 @@ packages:
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  - "stripe-core-2.5.0"
-  - "stripe-haskell-2.5.0"
-  - "stripe-http-client-2.5.0"
   - github: "PrivateStorageio/servant-prometheus"
     commit: "b9461cbf689b47506b2eee973136706092b74968"
     # https://input-output-hk.github.io/haskell.nix/tutorials/source-repository-hashes/#stack


### PR DESCRIPTION
We have been using a very old stack resolver since ... it was not as old.  Some servant-prometheus maintenance requires some package updates and to be compatible with the result, we should also update PaymentServer.

We need to update Haskell.nix too, because it doesn't know about a sufficiently new LTS resolver.

We don't update Haskell.nix *all* the way right now because https://github.com/input-output-hk/haskell.nix/pull/1641 changed the way pkg-config packages are specified and that breaks our build by causing libchallenge_bypass_ristretto_ffi to not be found.  There was some follow-up work to re-add a supported way of specifying such dependencies, https://github.com/input-output-hk/haskell.nix/issues/1664, but I haven't figured out how to use it yet.