### PR TITLE
Update to servant-prometheus with its own updated dependencies

### DIFF
--- a/nix/materialized.paymentserver/.stack-to-nix.cache
+++ b/nix/materialized.paymentserver/.stack-to-nix.cache
@@ -1,1 +1,1 @@
-https://github.com/PrivateStorageio/servant-prometheus.git b9461cbf689b47506b2eee973136706092b74968 . 1gfslw670ri119bnq3szc8b08n504f8cnzs5cgk5qvfwvfmsr1xh servant-prometheus .stack-to-nix.cache.0
+https://github.com/PrivateStorageio/servant-prometheus.git 6c8430b802303f9b8a3d11acb0c212b80444ad7c . 09dcwj5ac2x2ilb4a0rai3qhl875vvvjr12af5plpz86faga3lnz servant-prometheus .stack-to-nix.cache.0

--- a/nix/materialized.paymentserver/.stack-to-nix.cache.0
+++ b/nix/materialized.paymentserver/.stack-to-nix.cache.0
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "servant-prometheus"; version = "0.2.0.0"; };
+      identifier = { name = "servant-prometheus"; version = "0.2.1.0"; };
       license = "BSD-3-Clause";
       copyright = "";
       maintainer = "Alex Mason <axman6@gmail.com>, Jack Kelly <jack.kelly@data61.csiro.au>";
@@ -76,5 +76,5 @@
         };
       };
     } // rec {
-    src = (pkgs.lib).mkDefault /nix/store/zvvv6lxnqnva4302265x8wwbyb0mfy56-servant-prometheus-b9461cb;
+    src = (pkgs.lib).mkDefault /nix/store/g62jlfm3vg9dld12fi12f5rkp9sjgbab-servant-prometheus-6c8430b;
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,9 +39,9 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - github: "PrivateStorageio/servant-prometheus"
-    commit: "b9461cbf689b47506b2eee973136706092b74968"
+    commit: "622eb77cb08c5f13729173b8feb123a6700ff91f"
     # https://input-output-hk.github.io/haskell.nix/tutorials/source-repository-hashes/#stack
-    # nix-sha256: 1gfslw670ri119bnq3szc8b08n504f8cnzs5cgk5qvfwvfmsr1xh
+    # nix-sha256: 09dcwj5ac2x2ilb4a0rai3qhl875vvvjr12af5plpz86faga3lnz
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Bump to the latest servant-prometheus to ease development on recent system with recent versions of things.
