### PR TITLE
[in-repo] Skip cachix if credentials missing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,24 @@ jobs:
               if [ -v CACHIX_AUTH_TOKEN ]; then
                 cachix watch-exec "${CACHIX_NAME}" -- "$@"
               else
-                "$@"
+                # If we're building a from a forked repository then we're
+                # allowed to not have the credentials (but it's also fine if
+                # the owner of the fork supplied their own).
+                #
+                # https://circleci.com/docs/built-in-environment-variables/ says
+                # about `CIRCLE_PR_REPONAME`:
+                #
+                #   The name of the GitHub or Bitbucket repository where the
+                #   pull request was created. Only available on forked PRs.
+                #
+                # So if it is not set then we should have had credentials and we
+                # fail if we get here.
+                if [ -v CIRCLE_PR_REPONAME ]; then
+                  "$@"
+                else
+                  echo "Required credentials (CACHIX_AUTH_TOKEN) are missing."
+                  exit 1
+                fi
               fi
             }
             EOF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,34 @@ jobs:
       - "checkout"
 
       - run:
+          name: "Define Cache Helper"
+          command: |
+            # Define a function in the CircleCI shared-across-steps
+            # configuration file so we can share the cache-related logic
+            # across the next few steps.
+            #
+            # The escape on the heredoc syntax is required by CircleCI.
+            echo >> "$BASH_ENV" \<<EOF
+            function maybe-cache() {
+              # The `cachix watch-exec ...` does our cache population.  When
+              # it sees something added to the store (I guess) it pushes it to
+              # the named cache.
+              #
+              # We can only *push* to it if we have a CACHIX_AUTH_TOKEN,
+              # though.  in-repo jobs will get this from CircleCI
+              # configuration but jobs from forks may not.
+              if [ -v CACHIX_AUTH_TOKEN ]; then
+                cachix watch-exec "${CACHIX_NAME}" -- "$@"
+              else
+                "$@"
+              fi
+            }
+            EOF
+
+      - run:
           name: "Building with Nix"
           command: |
-            # The `cachix watch-exec ...` does our cache population.  When it
-            # sees something added to the store (I guess) it pushes it to the
-            # named cache.
-            cachix watch-exec "${CACHIX_NAME}" -- nix-build \
+            maybe-cache nix-build \
               --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
               --option extra-trusted-public-keys "${TRUSTED_PUBLIC_KEYS}" \
               -j 4 \
@@ -90,7 +112,7 @@ jobs:
       - run:
           name: "Building Tests"
           command: |
-            cachix watch-exec "${CACHIX_NAME}" -- nix-build \
+            maybe-cache nix-build \
               --option extra-substituters "${EXTRA_SUBSTITUTERS}" \
               --option extra-trusted-public-keys "${TRUSTED_PUBLIC_KEYS}" \
               -j 4 \


### PR DESCRIPTION
Fixes build failures on PRs from repo forks.  This is the in-repo version for testing to see if this variation still works correctly.
