### PR TITLE
Remove knowledge of chargeId from Persistence

### DIFF
--- a/src/PaymentServer/Processors/Stripe.hs
+++ b/src/PaymentServer/Processors/Stripe.hs
@@ -74,6 +74,7 @@ import Web.Stripe.Error
   )
 import Web.Stripe.Types
   ( Charge(Charge, chargeId)
+  , ChargeId
   , MetaData(MetaData)
   , Currency(USD)
   )
@@ -186,17 +187,17 @@ charge stripeConfig d (Charges token voucher 650 USD) = do
       let err = errorForStripe errorType ( concat [ "Stripe charge didn't succeed: ", msg ])
       throwError err
 
-    Right chargeId -> return Ok
+    Right _ -> return Ok
 
     where
-      payForVoucher' :: IO ProcessorResult
+      payForVoucher' :: IO (ProcessorResult ChargeId)
       payForVoucher' = do
         payForVoucher d voucher (completeStripeCharge USD) `catch` (
           \(e :: PaymentError) -> return $ Left e
           )
 
       tokenId = TokenId token
-      completeStripeCharge :: Currency -> IO ProcessorResult
+      completeStripeCharge :: Currency -> IO (ProcessorResult ChargeId)
       completeStripeCharge currency = do
         result <- stripe stripeConfig charge
         case result of

--- a/test/Persistence.hs
+++ b/test/Persistence.hs
@@ -83,18 +83,18 @@ aChargeId :: ChargeId
 aChargeId = ChargeId "abc"
 
 -- Mock a successful payment.
-paySuccessfully :: IO ProcessorResult
+paySuccessfully :: IO (ProcessorResult ChargeId)
 paySuccessfully = return . Right $ aChargeId
 
 -- Mock a failed payment.
-failPayment :: IO ProcessorResult
+failPayment :: IO (ProcessorResult ChargeId)
 failPayment = throwIO ArbitraryException
 
 -- Mock a payment that fails at the processor rather than with an IO
 -- exception.
 aStripeError :: StripeError
 aStripeError = StripeError CardError "Card rejected because reasons" Nothing Nothing Nothing
-failPaymentProcessing :: IO ProcessorResult
+failPaymentProcessing :: IO (ProcessorResult ChargeId)
 failPaymentProcessing = return $ Left $ PaymentFailed aStripeError
 
 -- | Create a group of tests related to voucher payment and redemption.


### PR DESCRIPTION
We won't persist the chargeId anymore and we won't require that the payment processor give us a chargeId so we will be able to support using Stripe in a mode where the chargeId is not readily accessible.

Fixes #125 