### PR TITLE
Fix SigningKeyAllocation issuer failures

### DIFF
--- a/PaymentServer.cabal
+++ b/PaymentServer.cabal
@@ -87,6 +87,7 @@ test-suite PaymentServer-tests
                      , Metrics
                      , Stripe
                      , FakeStripe
+                     , Ristretto
   build-depends:       aeson
                      , base
                      , bytestring

--- a/nix/materialized.paymentserver/PaymentServer.nix
+++ b/nix/materialized.paymentserver/PaymentServer.nix
@@ -138,6 +138,7 @@
             "Metrics"
             "Stripe"
             "FakeStripe"
+            "Ristretto"
             ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Spec.hs" ];

--- a/src/PaymentServer/Issuer.hs
+++ b/src/PaymentServer/Issuer.hs
@@ -48,13 +48,13 @@ data ChallengeBypass =
 -- | An issuer accepts a list of blinded tokens and returns signatures of
 -- those tokens along with proof that it used a particular key to construct
 -- the signatures.
-type Issuer = [BlindedToken] -> Either Text ChallengeBypass
+type Issuer = [BlindedToken] -> IO (Either Text ChallengeBypass)
 
 -- | trivialIssue makes up and returns some nonsense values that satisfy the
 -- structural requirements but not the semantic ones.
 trivialIssue :: Issuer
 trivialIssue tokens =
-  Right $
+  return . Right $
   ChallengeBypass
   "fake-public-key"
   (replicate (length tokens) "fake-signature")
@@ -67,7 +67,7 @@ ristrettoIssue
   :: SigningKey    -- ^ The key to provide to the PrivacyPass signer.
   -> Issuer        -- ^ An issuer using the given key.
 ristrettoIssue signingKey tokens = do
-  let issuance = ristretto signingKey tokens
+  issuance <- ristretto signingKey tokens
   case issuance of
-    Right (Issuance publicKey tokens proof) -> Right $ ChallengeBypass publicKey tokens proof
-    Left err -> Left . pack . show $ err
+    Right (Issuance publicKey tokens proof) -> return . Right $ ChallengeBypass publicKey tokens proof
+    Left err -> return . Left . pack . show $ err

--- a/src/PaymentServer/Redemption.hs
+++ b/src/PaymentServer/Redemption.hs
@@ -260,8 +260,9 @@ redeem (RedemptionConfig numGroups tokensPerVoucher issue) database (Redeem vouc
           throwError $ jsonErr err400 $ OtherFailure "fingerprint already used"
         Left DatabaseUnavailable -> do
           throwError $ jsonErr err500 $ OtherFailure "database temporarily unavailable"
-        Right fresh ->
-          case issue tokens of
+        Right fresh -> do
+          issuance <- liftIO $ issue tokens
+          case issuance of
             Left reason -> do
               throwError $ jsonErr err400 $ OtherFailure reason
             Right (ChallengeBypass key signatures proof) -> do

--- a/src/PaymentServer/Ristretto.hs
+++ b/src/PaymentServer/Ristretto.hs
@@ -164,12 +164,10 @@ randomSigningKey = do
 -- | randomToken generates a new token at random and returns it encoded as a
 -- base64 string.
 randomToken :: IO Text
-randomToken = do
-  cToken <- token_random
-  cString <- token_encode_base64 cToken
-  result <- peekCString cString
-  free cString
-  return $ pack result
+randomToken =
+  bracket token_random token_destroy $ \cToken ->
+  bracket (token_encode_base64 cToken) free $ \cString ->
+  pack <$> peekCAString cString
 
 -- | blindToken takes a token encoded as base64 and returns the base64
 -- encoding of the blinding of the token.

--- a/src/PaymentServer/Ristretto.hs
+++ b/src/PaymentServer/Ristretto.hs
@@ -104,9 +104,9 @@ data RistrettoFailure
 nullIsError :: b -> IO (Ptr a) -> ExceptT b IO (Ptr a)
 nullIsError fallback op =
   liftIO op >>= \r ->
-                  case r of
-                    nullPtr -> throwError fallback
-                    ptr -> return ptr
+                  if r == nullPtr
+                  then throwError fallback
+                  else return r
 
 anyNullIsError :: b -> IO [Ptr a] -> ExceptT b IO [Ptr a]
 anyNullIsError fallback op =

--- a/src/PaymentServer/Ristretto.hs
+++ b/src/PaymentServer/Ristretto.hs
@@ -153,13 +153,10 @@ ristretto textSigningKey textTokens =
 -- | randomSigningKey generates a new signing key at random and returns it
 -- encoded as a base64 string.
 randomSigningKey :: IO Text
-randomSigningKey = do
-  cSigningKey <- signing_key_random
-  cString <- signing_key_encode_base64 cSigningKey
-  signing_key_destroy cSigningKey
-  result <- peekCString cString
-  free cString
-  return $ pack result
+randomSigningKey =
+  bracket signing_key_random signing_key_destroy $ \cSigningKey ->
+  bracket (signing_key_encode_base64 cSigningKey) free $ \cString ->
+  pack <$> peekCAString cString
 
 -- | randomToken generates a new token at random and returns it encoded as a
 -- base64 string.

--- a/test/Ristretto.hs
+++ b/test/Ristretto.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Tests related to PaymentServer.Ristretto.
+
+module Ristretto
+  ( tests
+  ) where
+
+import Test.Tasty
+  ( TestTree
+  , testGroup
+  )
+
+import Test.Tasty.HUnit
+  ( testCase
+  , assertEqual
+  , assertFailure
+  )
+
+import PaymentServer.Ristretto
+  ( Issuance(Issuance, publicKey, signatures, proof)
+  , ristretto
+  , randomSigningKey
+  , randomToken
+  , blindToken
+  , getPublicKey
+  )
+
+tests :: TestTree
+tests = testGroup "Ristretto"
+  [ issueTests
+  ]
+
+issueTests :: TestTree
+issueTests = testGroup "Issuance"
+  [ testCase "ristretto returns an issuance" $ do
+      key <- randomSigningKey
+      expectedPublicKey <- getPublicKey key
+      aToken <- randomToken
+      aBlindToken <- blindToken aToken
+      let blindedTokens = [aBlindToken]
+      result <- ristretto key blindedTokens
+      case result of
+        (Right Issuance { publicKey, signatures, proof }) -> do
+          assertEqual "The public key matches the signing key." expectedPublicKey publicKey
+          assertEqual "The number of signatures equals the number of tokens." (length blindedTokens) (length signatures)
+          -- XXX The proof checks out
+        Left err -> do
+          assertFailure $ show err
+  ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,6 +14,7 @@ import qualified Persistence
 import qualified Metrics
 import qualified Stripe
 import qualified Redemption
+import qualified Ristretto
 
 tests :: TestTree
 tests = testGroup "Tests"
@@ -21,6 +22,7 @@ tests = testGroup "Tests"
   , Metrics.tests
   , Stripe.tests
   , Redemption.tests
+  , Ristretto.tests
   ]
 
 main = defaultMain tests


### PR DESCRIPTION
Fixes #132 

c5a4192ce6b6ab5179f198cddfac0f3fc3b66e47 adds a test.  b652f35669c97e23cf3bb08c589bed40efa1e753 makes it pass.  Everything in between is good but not directly relevant.
